### PR TITLE
MAINT: update install notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Please note that this software is now an alpha release. Initial conda packages a
  conda create -n q2-fmt-alpha \
    -c conda-forge \
    -c bioconda \
-   -c https://packages.qiime2.org/qiime2/2022.4/tested/ \
+   -c https://packages.qiime2.org/qiime2/2022.11/tested/ \
    q2-fmt q2cli
 ```
 Then activate your new environment as usual.


### PR DESCRIPTION
the current install instructions result in a broken deployment due to SciPy backward incompatible change:

```
ImportError: cannot import name 'PearsonRConstantInputWarning' from 'scipy.stats' (/Users/gregcaporaso/miniconda3/envs/q2-fmt-t1/lib/python3.8/site-packages/scipy/stats/__init__.py)
```
