### PR TITLE
MAINT: adding group_timepoints to __init__

### DIFF
--- a/q2_fmt/__init__.py
+++ b/q2_fmt/__init__.py
@@ -7,9 +7,9 @@
 # ----------------------------------------------------------------------------
 
 from ._version import get_versions
-from ._engraftment import engraftment
+from ._engraftment import engraftment, group_timepoints
 
 __version__ = get_versions()['version']
 del get_versions
 
-__all__ = ['engraftment']
+__all__ = ['engraftment', 'group_timepoints']


### PR DESCRIPTION
this PR adds `group_timepoints` for direct import - for consistency, since this was already added for `engraftment`.