### PR TITLE
BUG: remove composition table as input option for Sample PEDS

### DIFF
--- a/q2_fmt/plugin_setup.py
+++ b/q2_fmt/plugin_setup.py
@@ -15,7 +15,7 @@ from q2_types.distance_matrix import DistanceMatrix
 
 import q2_fmt
 from q2_types.feature_table import (
-    FeatureTable, Frequency, RelativeFrequency, PresenceAbsence, Composition)
+    FeatureTable, Frequency, RelativeFrequency, PresenceAbsence)
 from q2_stats._type import (GroupDist, Matched, Independent, Ordered,
                             Unordered, StatsTable, Pairwise)
 import q2_fmt._examples as ex
@@ -185,7 +185,7 @@ plugin.methods.register_function(
 plugin.methods.register_function(
     function=q2_fmt.sample_peds,
     inputs={'table': FeatureTable[Frequency | RelativeFrequency |
-                                  PresenceAbsence | Composition]},
+                                  PresenceAbsence]},
     parameters={'metadata': Metadata, 'time_column': Str,
                 'reference_column': Str, 'subject_column': T_subject,
                 'filter_missing_references': Bool,


### PR DESCRIPTION
Composition tables are not a valid option for PEDS. PEDS is based on present/absence of features and Composition tables do not have 0 values. (Described in q2-types "A feature table (e.g., samples by ASVs) where each value in the matrix is a whole number greater than 0 representing the frequency or count of a feature in the corresponding sample. "). Therefore PEDS would calculate this as 100% engraftment of 100% of features in the feature table. 