### PR TITLE
BUG: Fixing Feature ID Label visibility in feature PEDS

### DIFF
--- a/q2_fmt/_visualizer.py
+++ b/q2_fmt/_visualizer.py
@@ -38,7 +38,7 @@ def plot_heatmap(output_dir: str, data: pd.DataFrame):
             seen[most_specific] += 1
         data['y_label'] = y_labels
 
-        data['id'] = [id_.replace(';', ' ') for id_ in data['id']]
+        data['id'] = [i.replace(';', ' ') for i in data['id']]
         data['subject'] = [id_.replace(';', ' ') for id_ in data['subject']]
 
         data['y_label'].attrs.update({

--- a/q2_fmt/_visualizer.py
+++ b/q2_fmt/_visualizer.py
@@ -29,7 +29,7 @@ def plot_heatmap(output_dir: str, data: pd.DataFrame):
         for i, sub in enumerate(data['subject']):
             fields = [field for field in sub.split(';')
                       if not field.endswith('__')]
-            subject_seen.append(e)
+            subject_seen.append(sub)
             most_specific = fields[-1]
             if most_specific in seen and e not in subject_seen:
                 y_labels.append(f"{seen[most_specific]}: {most_specific} *")

--- a/q2_fmt/_visualizer.py
+++ b/q2_fmt/_visualizer.py
@@ -31,7 +31,7 @@ def plot_heatmap(output_dir: str, data: pd.DataFrame):
                       if not field.endswith('__')]
             subject_seen.append(sub)
             most_specific = fields[-1]
-            if most_specific in seen and e not in subject_seen:
+            if most_specific in seen and sub not in subject_seen:
                 y_labels.append(f"{seen[most_specific]}: {most_specific} *")
             else:
                 y_labels.append(most_specific)

--- a/q2_fmt/_visualizer.py
+++ b/q2_fmt/_visualizer.py
@@ -26,7 +26,7 @@ def plot_heatmap(output_dir: str, data: pd.DataFrame):
         y_labels = []
         seen = Counter()
         subject_seen = []
-        for i, e in enumerate(data['subject']):
+        for i, sub in enumerate(data['subject']):
             fields = [field for field in sub.split(';')
                       if not field.endswith('__')]
             subject_seen.append(e)

--- a/q2_fmt/_visualizer.py
+++ b/q2_fmt/_visualizer.py
@@ -39,7 +39,7 @@ def plot_heatmap(output_dir: str, data: pd.DataFrame):
         data['y_label'] = y_labels
 
         data['id'] = [i.replace(';', ' ') for i in data['id']]
-        data['subject'] = [id_.replace(';', ' ') for id_ in data['subject']]
+        data['subject'] = [i.replace(';', ' ') for i in data['subject']]
 
         data['y_label'].attrs.update({
                 'title': "Feature ID",

--- a/q2_fmt/_visualizer.py
+++ b/q2_fmt/_visualizer.py
@@ -27,7 +27,7 @@ def plot_heatmap(output_dir: str, data: pd.DataFrame):
         seen = Counter()
         subject_seen = []
         for i, e in enumerate(data['subject']):
-            fields = [field for field in e.split(';')
+            fields = [field for field in sub.split(';')
                       if not field.endswith('__')]
             subject_seen.append(e)
             most_specific = fields[-1]

--- a/q2_fmt/assets/spec.json
+++ b/q2_fmt/assets/spec.json
@@ -12,7 +12,7 @@
     {
       "name": "rowtable",
       "source": "table",
-      "transform": [{"type": "aggregate", "groupby": ["subject"]}]
+      "transform": [{"type": "aggregate", "groupby": ["y_label"]}]
     },
     {
       "name": "columntable",
@@ -47,9 +47,9 @@
   ],
   "scales": [
     {
-      "name": "subject",
+      "name": "y_label",
       "type": "band",
-      "domain": {"data": "table", "field": "subject"},
+      "domain": {"data": "table", "field": "y_label"},
       "range": "height",
       "paddingInner": 0.05
     },
@@ -69,7 +69,7 @@
     }
   ],
   "axes": [
-    {"scale": "subject", "orient": "left", "title":{"signal": "y_label"}},
+    {"scale": "y_label", "orient": "left", "title":{"signal": "y_label"}},
     {"scale": "time", "orient": "bottom", "title":{"signal": "x_label"}}
   ],
   "marks": [
@@ -78,9 +78,9 @@
       "from": {"data": "table"},
       "encode": {
         "update": {
-          "y": {"field": "subject", "scale": "subject"},
+          "y": {"field": "y_label", "scale": "y_label"},
           "x": {"field": "group", "scale": "time"},
-          "height": {"band": 1, "scale": "subject"},
+          "height": {"band": 1, "scale": "y_label"},
           "width": {"band": 1, "scale": "time"},
           "fill": {"scale": "color", "field": "measure"},
           "tooltip": {


### PR DESCRIPTION
This PR fixes the issue where the Feature PEDS heatmap y_label is truncated due to the length of the taxonomic label and address this issue: https://github.com/qiime2/q2-fmt/issues/50

With this PR: 
- feature heatmap truncates taxonomic labels and labels the heatmap with the most specific taxonomic level available in the taxonomic label. 
- It also replaces ; with ' ' in` Id column `and `subject column` to reformat the taxonomic label in the tooltip of the viz
Previous functionality:
![Screenshot 2023-05-05 at 10 27 35 AM](https://user-images.githubusercontent.com/60228108/236525905-b5550937-f45c-45d5-aa14-571e97bca605.png)
Functionality with this PR:
![Screenshot 2023-05-05 at 10 28 46 AM](https://user-images.githubusercontent.com/60228108/236526115-6e7610e1-1f17-406f-ad1c-75df3c55365d.png)

This PR adapts code from Greg's[ differential abundance plot](https://github.com/qiime2/q2-composition/blob/d8265fd270e0d2fe4b04783d2980d3a24cf9c0e9/q2_composition/_diff_abundance_plots.py#L58). 



