### PR TITLE
MAINT: adds colummn type function

### DIFF
--- a/q2_fmt/_peds.py
+++ b/q2_fmt/_peds.py
@@ -22,16 +22,19 @@ def sample_peds(table: pd.DataFrame, metadata: qiime2.Metadata,
     # TODO: Make incomplete samples possible move this to heatmap
     metadata = metadata.to_dataframe()
     num_timepoints = _check_for_time_column(metadata, time_column)
-    _check_time_column_numeric(column_properties, time_column)
+    _check_column_type(column_properties, "time",
+                       time_column, "numeric")
     reference_series = _check_reference_column(metadata, reference_column)
-    _check_reference_column_categorical(column_properties, reference_column)
+    _check_column_type(column_properties, "reference",
+                       reference_column, "categorical")
     # return things that should be removed
     metadata, used_references = \
         _filter_associated_reference(reference_series, metadata, time_column,
                                      filter_missing_references,
                                      reference_column)
     subject_series = _check_subject_column(metadata, subject_column)
-    _check_subject_column_categorical(column_properties, subject_column)
+    _check_column_type(column_properties, "subject",
+                       subject_column, "categorical")
     _check_duplicate_subject_timepoint(subject_series, metadata,
                                        subject_column, time_column)
     # return things that should be removed
@@ -62,15 +65,18 @@ def feature_peds(table: pd.DataFrame, metadata: qiime2.Metadata,
     metadata = metadata.to_dataframe()
 
     _ = _check_for_time_column(metadata, time_column)
-    _check_time_column_numeric(column_properties, time_column)
+    _check_column_type(column_properties, "time",
+                       time_column, "numeric")
     reference_series = _check_reference_column(metadata, reference_column)
-    _check_reference_column_categorical(column_properties, reference_column)
+    _check_column_type(column_properties, "reference",
+                       reference_column, "categorical")
     metadata, used_references = \
         _filter_associated_reference(reference_series, metadata, time_column,
                                      filter_missing_references,
                                      reference_column)
     _ = _check_subject_column(metadata, subject_column)
-    _check_subject_column_categorical(column_properties, subject_column)
+    _check_column_type(column_properties, "subject",
+                       subject_column, "categorical")
     peds_df = pd.DataFrame(columns=['id', 'measure', 'recipients with feature',
                                     'all possible recipients with feature',
                                     'group', 'subject'])
@@ -198,17 +204,6 @@ def _check_for_time_column(metadata, time_column):
     return num_timepoints
 
 
-def _check_time_column_numeric(column_properties, time_column):
-    try:
-        assert column_properties[time_column].type == 'numeric'
-    except AssertionError as e:
-        raise AssertionError('Non-numeric values found in `--p-time-column`.'
-                             ' Please make sure the column selected contains'
-                             ' only simple integer values. Column with'
-                             ' non-numeric values that was'
-                             ' selected: %s' % time_column) from e
-
-
 def _check_reference_column(metadata, reference_column):
     try:
         reference_series = metadata[reference_column]
@@ -243,16 +238,6 @@ def _filter_associated_reference(reference_series, metadata, time_column,
                            ' IDs where missing references were found:'
                            ' %s' % (tuple(nan_references),))
     return metadata, used_references
-
-
-def _check_reference_column_categorical(column_properties, reference_column):
-    try:
-        assert column_properties[reference_column].type == 'categorical'
-    except AssertionError as e:
-        raise AssertionError('Numeric values found in `--p-reference-column`.'
-                             ' Please make sure the column selected is'
-                             ' categorical. Column with numeric values that'
-                             ' was selected: `%s`' % reference_column) from e
 
 
 def _check_subject_column(metadata, subject_column):
@@ -308,14 +293,16 @@ def _check_subjects_in_all_timepoints(subject_series, num_timepoints,
     return metadata, used_references
 
 
-def _check_subject_column_categorical(column_properties, subject_column):
+def _check_column_type(column_properties, parameter_type, column, column_type):
     try:
-        assert column_properties[subject_column].type == 'categorical'
+        assert column_properties[column].type == column_type
     except AssertionError as e:
-        raise AssertionError('Numeric values found in `--p-subject-column`.'
-                             ' Please make sure the column selected is'
-                             ' categorical. Column with numeric values that'
-                             ' was selected: `%s`' % subject_column) from e
+        raise AssertionError('Non-%s values found in `--p-%s-column`.'
+                             ' Please make sure the column selected contains'
+                             ' the correct MetadataColumn type. Column with'
+                             ' non-%s values that was'
+                             ' selected: `%s`' % (column_type, parameter_type,
+                                                  column_type, column)) from e
 
 
 # PEDS calculation methods

--- a/q2_fmt/tests/test_engraftment.py
+++ b/q2_fmt/tests/test_engraftment.py
@@ -17,9 +17,8 @@ from q2_fmt._engraftment import group_timepoints
 from q2_fmt._peds import (_compute_peds, sample_peds,
                           _filter_associated_reference,
                           _check_reference_column, _check_for_time_column,
-                          _check_subject_column, _check_time_column_numeric,
-                          _check_reference_column_categorical,
-                          _check_subject_column_categorical, feature_peds)
+                          _check_subject_column, _check_column_type,
+                          feature_peds)
 
 
 class TestBase(TestPluginBase):
@@ -916,7 +915,7 @@ class TestPeds(TestBase):
                          reference_column="Ref",
                          subject_column="subject")
 
-    def test_group_column_categorical(self):
+    def test_column_type_nonnumeric(self):
         metadata_df = pd.DataFrame({
             'id': ['sample1', 'sample2', 'sample3', 'sample4',
                    'donor1', 'donor2'],
@@ -929,10 +928,10 @@ class TestPeds(TestBase):
         metadata_obj = Metadata(metadata_df)
         column_properties = metadata_obj.columns
         with self.assertRaisesRegex(AssertionError, ".*Column with non-numeric"
-                                    " values that was selected: group"):
-            _check_time_column_numeric(column_properties, 'group')
+                                    " values that was selected: `group`"):
+            _check_column_type(column_properties, 'time', 'group', 'numeric')
 
-    def test_subject_column_numeric(self):
+    def test_column_type_noncategorical(self):
         metadata_df = pd.DataFrame({
             'id': ['sample1', 'sample2', 'sample3', 'sample4',
                    'donor1', 'donor2'],
@@ -944,25 +943,11 @@ class TestPeds(TestBase):
                       float("Nan")]}).set_index('id')
         metadata_obj = Metadata(metadata_df)
         column_properties = metadata_obj.columns
-        with self.assertRaisesRegex(AssertionError, ".*Column with numeric"
-                                    " values that was selected: `subject`"):
-            _check_subject_column_categorical(column_properties, 'subject')
-
-    def test_reference_column_numeric(self):
-        metadata_df = pd.DataFrame({
-            'id': ['sample1', 'sample2', 'sample3', 'sample4',
-                   "1", "2"],
-            'Ref': [1, 1, 1, 2, float("Nan"),
-                    float("Nan")],
-            'subject': ['sub1', 'sub1', 'sub1', 'sub2', float("Nan"),
-                        float("Nan")],
-            'group': [1, 2, 3, 2, float("Nan"),
-                      float("Nan")]}).set_index('id')
-        metadata_obj = Metadata(metadata_df)
-        column_properties = metadata_obj.columns
-        with self.assertRaisesRegex(AssertionError, ".*Column with numeric"
-                                    " values that was selected: `Ref`"):
-            _check_reference_column_categorical(column_properties, 'Ref')
+        with self.assertRaisesRegex(AssertionError, ".*Column with"
+                                    " non-categorical values that was"
+                                    " selected: `subject`"):
+            _check_column_type(column_properties, 'subject', 'subject',
+                               'categorical')
 
     def test_reference_series_not_in_table(self):
         metadata_df = pd.DataFrame({


### PR DESCRIPTION
This PR refactors peds to use a _check_column_type() function instead of redundant code to check the column type of subject, time and reference columns individually. 
This PR: 

- Adds and Implements _check_column_type()
- reduces unit tests to test non-numeric and non-categorical error messages

This should fix issue https://github.com/qiime2/q2-fmt/issues/53