### PR TITLE
MAINT: adds drop_incomplete_timepoint parameter to sample-peds

### DIFF
--- a/q2_fmt/_peds.py
+++ b/q2_fmt/_peds.py
@@ -280,7 +280,7 @@ def _drop_incomplete_timepoints(metadata, time_column,
             assert (float(time)
                     in metadata[time_column].unique())
         except AssertionError as e:
-            raise AssertionError('The provide incomplete timepoint `%s` was'
+            raise AssertionError('The provided incomplete timepoint `%s` was'
                                  ' not found in the metadata. Please check'
                                  ' that the incomplete timepoint provided is'
                                  ' in your provided --p-time-column: `%s`'

--- a/q2_fmt/_peds.py
+++ b/q2_fmt/_peds.py
@@ -16,7 +16,7 @@ def sample_peds(table: pd.DataFrame, metadata: qiime2.Metadata,
                 time_column: str, reference_column: str, subject_column: str,
                 filter_missing_references: bool = False,
                 drop_incomplete_subjects: bool = False,
-                drop_incomplete_timepoint: str = None) -> (pd.DataFrame):
+                drop_incomplete_timepoint: list = None) -> (pd.DataFrame):
     ids_with_data = table.index
     metadata = metadata.filter_ids(ids_to_keep=ids_with_data)
     column_properties = metadata.columns
@@ -275,17 +275,18 @@ def _check_duplicate_subject_timepoint(subject_series, metadata,
 
 def _drop_incomplete_timepoints(metadata, time_column,
                                 drop_incomplete_timepoint):
-    try:
-        assert (float(drop_incomplete_timepoint)
-                in metadata[time_column].unique())
-    except AssertionError as e:
-        raise AssertionError('The provide incomplete timepoint `%s` was not'
-                             ' found in the metadata. Please check that the'
-                             ' incomplete timepoint provided is in your'
-                             ' provided --p-time-column: `%s`'
-                             % (drop_incomplete_timepoint, time_column)) from e
-    metadata = metadata[metadata[time_column] !=
-                        float(drop_incomplete_timepoint)]
+    for time in drop_incomplete_timepoint:
+        try:
+            assert (float(time)
+                    in metadata[time_column].unique())
+        except AssertionError as e:
+            raise AssertionError('The provide incomplete timepoint `%s` was'
+                                 ' not found in the metadata. Please check'
+                                 ' that the incomplete timepoint provided is'
+                                 ' in your provided --p-time-column: `%s`'
+                                 % (time, time_column)) from e
+        metadata = metadata[metadata[time_column] !=
+                            float(time)]
     return metadata
 
 
@@ -308,8 +309,12 @@ def _check_subjects_in_all_timepoints(subject_series, num_timepoints,
                                     != num_timepoints].index).to_list()
             raise ValueError('Missing timepoints for associated subjects.'
                              ' Please make sure that all subjects have all'
-                             ' timepoints or use drop_incomplete_subjects'
-                             ' parameter. The incomplete subjects were %s'
+                             ' timepoints. You can drop these subjects by'
+                             ' using the drop_incomplete_subjects parameter or'
+                             ' drop any timepoints that have large numbers'
+                             ' of subjects missing by using the'
+                             ' drop_incomplete_timepoints parameter. The'
+                             ' incomplete subjects were %s'
                              % incomplete_subjects)
     return metadata, used_references
 

--- a/q2_fmt/plugin_setup.py
+++ b/q2_fmt/plugin_setup.py
@@ -189,7 +189,8 @@ plugin.methods.register_function(
     parameters={'metadata': Metadata, 'time_column': Str,
                 'reference_column': Str, 'subject_column': T_subject,
                 'filter_missing_references': Bool,
-                'drop_incomplete_subjects': Bool},
+                'drop_incomplete_subjects': Bool,
+                'drop_incomplete_timepoint': Str},
     outputs=[('peds_dists', GroupDist[Ordered, Matched] % Properties("peds"))],
     parameter_descriptions={
         'metadata': 'The sample metadata.',
@@ -210,6 +211,11 @@ plugin.methods.register_function(
         'drop_incomplete_subjects': 'Filter out subjects that do not have'
                                     ' a sample at every timepoint.'
                                     ' Default behavior is to raise an error.',
+        'drop_incomplete_timepoint': 'Filter out a provided timepoint. This'
+                                     ' will be preformed before'
+                                     ' drop_incomplete_subjects if the'
+                                     ' drop_incomplete_subjects parameter is'
+                                     ' passed.'
     },
     output_descriptions={
         'peds_dists': 'The distributions for the PEDS measure,'

--- a/q2_fmt/plugin_setup.py
+++ b/q2_fmt/plugin_setup.py
@@ -9,7 +9,8 @@
 import importlib
 
 from qiime2.plugin import (Str, Plugin, Metadata, TypeMap,
-                           Bool, Choices, Visualization, Properties, Citations)
+                           Bool, Choices, Visualization, Properties, Citations,
+                           List)
 from q2_types.sample_data import SampleData, AlphaDiversity
 from q2_types.distance_matrix import DistanceMatrix
 
@@ -190,7 +191,7 @@ plugin.methods.register_function(
                 'reference_column': Str, 'subject_column': T_subject,
                 'filter_missing_references': Bool,
                 'drop_incomplete_subjects': Bool,
-                'drop_incomplete_timepoint': Str},
+                'drop_incomplete_timepoint': List[Str]},
     outputs=[('peds_dists', GroupDist[Ordered, Matched] % Properties("peds"))],
     parameter_descriptions={
         'metadata': 'The sample metadata.',
@@ -211,8 +212,8 @@ plugin.methods.register_function(
         'drop_incomplete_subjects': 'Filter out subjects that do not have'
                                     ' a sample at every timepoint.'
                                     ' Default behavior is to raise an error.',
-        'drop_incomplete_timepoint': 'Filter out a provided timepoint. This'
-                                     ' will be preformed before'
+        'drop_incomplete_timepoint': 'Filter out a list of provided timepoint.'
+                                     ' This will be preformed before'
                                      ' drop_incomplete_subjects if the'
                                      ' drop_incomplete_subjects parameter is'
                                      ' passed.'

--- a/q2_fmt/tests/test_engraftment.py
+++ b/q2_fmt/tests/test_engraftment.py
@@ -630,10 +630,13 @@ class TestPeds(TestBase):
             'Feature2': [1, 1, 1, 1, 1, 1]}).set_index('id')
         with self.assertRaisesRegex(ValueError, 'Missing timepoints for'
                                     ' associated subjects. Please make sure'
-                                    ' that all subjects have all timepoints'
-                                    ' or use drop_incomplete_subjects'
-                                    ' parameter. .*'
-                                    ' [\'sub2\']'):
+                                    ' that all subjects have all timepoints.'
+                                    ' You can drop these subjects by using the'
+                                    ' drop_incomplete_subjects parameter or'
+                                    ' drop any timepoints that have large'
+                                    ' numbers of subjects missing by using the'
+                                    ' drop_incomplete_timepoints parameter. .*'
+                                    '[\'sub2\']'):
             sample_peds(table=table_df, metadata=metadata,
                         time_column="group",
                         reference_column="Ref",
@@ -1033,6 +1036,20 @@ class TestPeds(TestBase):
                         float("Nan")],
             'group': [1, 2, 3, 2, float("Nan"),
                       float("Nan")]}).set_index('id')
-        metadata_df = _drop_incomplete_timepoints(metadata_df, "group", 3)
+        metadata_df = _drop_incomplete_timepoints(metadata_df, "group", [3])
         self.assertEqual(metadata_df["group"].unique()[0], float(1))
         self.assertEqual(metadata_df["group"].unique()[1], float(2))
+
+    def test_drop_incomplete_timepoints_list(self):
+        metadata_df = pd.DataFrame({
+            'id': ['sample1', 'sample2', 'sample3', 'sample4',
+                   'donor1', 'donor2'],
+            'Ref': ['donor1', 'donor1', 'donor1', 'donor2', float("Nan"),
+                    float("Nan")],
+            'subject': ['sub1', 'sub1', 'sub1', 'sub2', float("Nan"),
+                        float("Nan")],
+            'group': [1, 2, 3, 2, float("Nan"),
+                      float("Nan")]}).set_index('id')
+        metadata_df = _drop_incomplete_timepoints(metadata_df, "group", [3, 2])
+        self.assertEqual(metadata_df["group"].dropna().unique(), [float(1)])
+

--- a/q2_fmt/tests/test_engraftment.py
+++ b/q2_fmt/tests/test_engraftment.py
@@ -18,7 +18,7 @@ from q2_fmt._peds import (_compute_peds, sample_peds,
                           _filter_associated_reference,
                           _check_reference_column, _check_for_time_column,
                           _check_subject_column, _check_column_type,
-                          feature_peds)
+                          _drop_incomplete_timepoints, feature_peds)
 
 
 class TestBase(TestPluginBase):
@@ -1022,3 +1022,17 @@ class TestPeds(TestBase):
                                     " not be the same as the index of"
                                     " metadata: `id`"):
             _check_reference_column(metadata_df, "id")
+
+    def test_drop_incomplete_timepoints(self):
+        metadata_df = pd.DataFrame({
+            'id': ['sample1', 'sample2', 'sample3', 'sample4',
+                   'donor1', 'donor2'],
+            'Ref': ['donor1', 'donor1', 'donor1', 'donor2', float("Nan"),
+                    float("Nan")],
+            'subject': ['sub1', 'sub1', 'sub1', 'sub2', float("Nan"),
+                        float("Nan")],
+            'group': [1, 2, 3, 2, float("Nan"),
+                      float("Nan")]}).set_index('id')
+        metadata_df = _drop_incomplete_timepoints(metadata_df, "group", 3)
+        self.assertEqual(metadata_df["group"].unique()[0], float(1))
+        self.assertEqual(metadata_df["group"].unique()[1], float(2))

--- a/q2_fmt/tests/test_engraftment.py
+++ b/q2_fmt/tests/test_engraftment.py
@@ -1052,4 +1052,3 @@ class TestPeds(TestBase):
                       float("Nan")]}).set_index('id')
         metadata_df = _drop_incomplete_timepoints(metadata_df, "group", [3, 2])
         self.assertEqual(metadata_df["group"].dropna().unique(), [float(1)])
-


### PR DESCRIPTION
Closes https://github.com/qiime2/q2-fmt/issues/40

This PR adds the drop_incomplete_timepoint parameter to sample-peds. 

Sample-peds requires that subjects have all time points. Currently, sample-peds has a parameter to drop any subject that does not have all time points.

However, this might be problematic if there is a time point that most subjects do not have values for. Currently, this would result in sample-peds suggesting that you use the drop_incomplete_subjects parameter which would drop the majority of the subjects from the analysis. @ebolyen suggested adding a drop_incomplete_timepoint parameter in a[ previous review comment](https://github.com/qiime2/q2-fmt/pull/39#discussion_r1001204420). In this comment, it was discussed that the drop_incomplete_subjects and drop_incomplete_timepoints should be mutually exclusive.  I decided to make these independent parameters because I think there could be situation where there is a "dud time point" that should be dropped but also subjects that are not complete even after the  "dud time point" has been removed (i.e. there are missing another time point besides the "dud time point"