### PR TITLE
BUG: fixed heatmap pipeline return

### DIFF
--- a/q2_fmt/_peds.py
+++ b/q2_fmt/_peds.py
@@ -50,10 +50,11 @@ def peds(ctx, table, metadata, peds_metric, time_column, reference_column,
 
 
 def peds_heatmap(ctx, data):
+
     plot_heatmap = ctx.get_action('vizard', 'plot_heatmap')
     results = plot_heatmap(data, transpose=False, order='ascending')
 
-    return results
+    return tuple(results)
 
 
 def sample_peds(table: pd.DataFrame, metadata: qiime2.Metadata,

--- a/q2_fmt/_peds.py
+++ b/q2_fmt/_peds.py
@@ -50,7 +50,6 @@ def peds(ctx, table, metadata, peds_metric, time_column, reference_column,
 
 
 def peds_heatmap(ctx, data):
-
     plot_heatmap = ctx.get_action('vizard', 'plot_heatmap')
     results = plot_heatmap(data, transpose=False, order='ascending')
 


### PR DESCRIPTION
This PR address the issue where peds-heatmap returns a <class 'qiime2.sdk.results.Results'>  and not a Result object.


