### PR TITLE
REF: Refactoring peds-heatmap and the peds pipeline to split taxonomic labels

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - qiime2 {{ qiime2_epoch }}.*
     - q2-types {{ qiime2_epoch }}.*
     - q2-stats {{ qiime2_epoch }}.*
+    - q2-vizard {{ qiime2_epoch }}.*
 
 test:
   requires:

--- a/q2_fmt/_peds.py
+++ b/q2_fmt/_peds.py
@@ -50,10 +50,11 @@ def peds(ctx, table, metadata, peds_metric, time_column, reference_column,
 
 
 def peds_heatmap(ctx, data):
+
     plot_heatmap = ctx.get_action('vizard', 'plot_heatmap')
     results = plot_heatmap(data, transpose=False, order='ascending')
 
-    return results
+    return tuple(results)
 
 
 def sample_peds(table: pd.DataFrame, metadata: qiime2.Metadata,

--- a/q2_fmt/_peds.py
+++ b/q2_fmt/_peds.py
@@ -50,7 +50,6 @@ def peds(ctx, table, metadata, peds_metric, time_column, reference_column,
 
 
 def peds_heatmap(ctx, data):
-
     plot_heatmap = ctx.get_action('vizard', 'plot_heatmap')
     results = plot_heatmap(data, transpose=False, order='ascending')
 

--- a/q2_fmt/_peds.py
+++ b/q2_fmt/_peds.py
@@ -216,7 +216,7 @@ def _compute_peds(peds_df: pd.Series, peds_type: str, peds_time: int,
             peds_df.loc[len(peds_df)] = [feature, peds, num_sum[count],
                                          donor_sum[count], peds_time, feature]
             peds_df = peds_df.dropna()
-        
+
         peds_df['id'].attrs.update({
             'title': "Feature ID",
             'description': ''
@@ -270,7 +270,7 @@ def _rename_features(level_delimiter, data: pd.DataFrame):
         data['id'] = [i.replace(level_delimiter, ' ') for i in data['id']]
 
         # currently attrs get deleted with df is changed. right now the best
-        # way to solve this is by saving them as temp and saving them at the 
+        # way to solve this is by saving them as temp and saving them at the
         # end
 
         data['subject'].attrs.update({'title': subject_name,
@@ -432,4 +432,3 @@ def _create_masking(time_metadata, donor_df, recip_df, reference_column):
 def _mask_recipient(donor_mask, recip_df):
     maskedrecip = donor_mask & recip_df
     return maskedrecip
-

--- a/q2_fmt/_peds.py
+++ b/q2_fmt/_peds.py
@@ -12,7 +12,6 @@ import numpy as np
 import warnings
 from collections import Counter
 from q2_vizard import plot_heatmap
-import tempfile
 
 
 def peds(ctx, table, metadata, peds_metric, time_column, reference_column,
@@ -238,8 +237,6 @@ def _compute_peds(peds_df: pd.Series, peds_type: str, peds_time: int,
         raise KeyError('There was an error finding which PEDS methods to use')
     return peds_df
 
-#Prep method
-# TODO: Heatmap prep method: refactor after external heatmap wiring is complete
 # prep method
 def _rename_features(level_delimiter, data: pd.DataFrame):
     if ("recipients with feature" in data.columns and
@@ -437,40 +434,3 @@ def _mask_recipient(donor_mask, recip_df):
     maskedrecip = donor_mask & recip_df
     return maskedrecip
 
-# TODO: Heatmap prep method: refactor after external heatmap wiring is complete
-# prep method
-    # if ("recipients with feature" in data.columns and
-    #         level_delimiter is not None):
-    #     y_labels = []
-    #     seen = Counter()
-    #     subject_seen = []
-    #     for i, sub in enumerate(data['subject']):
-    #         if level_delimiter in sub:
-    #             fields = [field for field in sub.split(level_delimiter)
-    #                       if not field.endswith('__')]
-    #         else:
-    # This is necessary to handle a case where the delimiter
-    # isn't found but the sub ends with __. In that case, sub would
-    # be completely thrown out.
-    #             fields = [sub]
-    #         subject_seen.append(sub)
-    #         most_specific = fields[-1]
-    #         if most_specific in seen and sub not in subject_seen:
-    #             y_labels.append(f"{seen[most_specific]}: {most_specific} *")
-    #         else:
-    #             y_labels.append(most_specific)
-    #         seen[most_specific] += 1
-    #     data['y_label'] = y_labels
-
-    #     data['id'] = [i.replace(level_delimiter, ' ') for i in data['id']]
-    #     data['subject'] = [i.replace(level_delimiter, ' ')
-    #                        for i in data['subject']]
-
-    #     data['y_label'].attrs.update({
-    #             'title': "Feature ID",
-    #             'description': ''})
-    # else:
-    #     data['y_label'] = data["subject"]
-    #     data['y_label'].attrs.update({
-    #             'title': subject_title_temp,
-    #             'description': ''})

--- a/q2_fmt/_peds.py
+++ b/q2_fmt/_peds.py
@@ -50,11 +50,10 @@ def peds(ctx, table, metadata, peds_metric, time_column, reference_column,
     return tuple(results)
 
 
-
-def peds_heatmap(output_dir: str, data:pd.DataFrame ,
-                 level_delimiter:str=None):
+def peds_heatmap(output_dir: str, data: pd.DataFrame,
+                 level_delimiter: str = None):
     _rename_features(data=data, level_delimiter=level_delimiter)
-    plot_heatmap(output_dir=output_dir, data=data, transpose=False, 
+    plot_heatmap(output_dir=output_dir, data=data, transpose=False,
                  order='ascending')
 
 
@@ -238,6 +237,7 @@ def _compute_peds(peds_df: pd.Series, peds_type: str, peds_time: int,
         raise KeyError('There was an error finding which PEDS methods to use')
     return peds_df
 
+
 # prep method
 def _rename_features(level_delimiter, data: pd.DataFrame):
     if ("recipients with feature" in data.columns and
@@ -245,7 +245,7 @@ def _rename_features(level_delimiter, data: pd.DataFrame):
         group_name = data["group"].attrs['title']
         subject_name = data["subject"].attrs['title']
         measure_name = data["measure"].attrs['title']
-    
+
         y_labels = []
         seen = Counter()
         subject_seen = []
@@ -254,9 +254,9 @@ def _rename_features(level_delimiter, data: pd.DataFrame):
                 fields = [field for field in sub.split(level_delimiter)
                           if not field.endswith('__')]
             else:
-        #This is necessary to handle a case where the delimiter
-        #isn't found but the sub ends with __. In that case, sub would
-        #be completely thrown out.
+                # This is necessary to handle a case where the delimiter
+                # isn't found but the sub ends with __. In that case, sub would
+                # be completely thrown out.
                 fields = [sub]
             subject_seen.append(sub)
             most_specific = fields[-1]
@@ -268,19 +268,17 @@ def _rename_features(level_delimiter, data: pd.DataFrame):
         data['subject'] = y_labels
 
         data['id'] = [i.replace(level_delimiter, ' ') for i in data['id']]
-        #data['subject'] = [i.replace(level_delimiter, ' ')
-         #                  for i in data['subject']]
 
-        #currently attrs get deleted with df is changed. right now the best
-        #way to solve this is by saving them as temp and saving them at the end
+        # currently attrs get deleted with df is changed. right now the best
+        # way to solve this is by saving them as temp and saving them at the 
+        # end
 
         data['subject'].attrs.update({'title': subject_name,
                                       'description': ''})
         data['group'].attrs.update({'title': group_name,
-                                      'description': ''})
+                                    'description': ''})
         data['measure'].attrs.update({'title': measure_name,
                                       'description': ''})
-        
 
 
 # Filtering methods

--- a/q2_fmt/plugin_setup.py
+++ b/q2_fmt/plugin_setup.py
@@ -193,7 +193,9 @@ plugin.pipelines.register_function(
                 'subject_column': T_subject,
                 'filter_missing_references': Bool,
                 'drop_incomplete_subjects': Bool,
-                'drop_incomplete_timepoint': List[Str]},
+                'drop_incomplete_timepoint': List[Str],
+                'level_delimiter': Str}
+                ,
     outputs=[('peds_heatmap', Visualization)],
     parameter_descriptions={},
     output_descriptions={},
@@ -201,14 +203,12 @@ plugin.pipelines.register_function(
     description=''
 )
 
-plugin.pipelines.register_function(
+plugin.visualizers.register_function(
     function=q2_fmt.peds_heatmap,
     inputs={'data': GroupDist[Ordered, Matched] % Properties("peds")},
-    parameters={},
-    outputs=[('peds_heatmap', Visualization)],
+    parameters={'level_delimiter': Str},
     parameter_descriptions={},
-    output_descriptions={},
-    name='',
+    name='PEDS Heatmap',
     description=''
 )
 
@@ -300,21 +300,5 @@ plugin.methods.register_function(
     }
 )
 
-# plugin.visualizers.register_function(
-#     function=q2_fmt.plot_heatmap,
-#     inputs={'data': GroupDist[Ordered, Matched] % Properties('peds')},
-#     parameters={'level_delimiter': Str},
-#     parameter_descriptions={'level_delimiter': 'If feature ids encode'
-#                                                ' hierarchical information,'
-#                                                ' split the levels when'
-#                                                ' generating feature labels'
-#                                                ' in the visualization using'
-#                                                ' this delimiter.'},
-#     name='Plot Heatmap',
-#     description='',
-#     examples={
-#         'peds_heatmap': ex.peds_heatmap
-#      }
-# )
 
 importlib.import_module('q2_fmt._transformer')

--- a/q2_fmt/plugin_setup.py
+++ b/q2_fmt/plugin_setup.py
@@ -190,7 +190,7 @@ plugin.pipelines.register_function(
     parameters={'metadata': Metadata,
                 'peds_metric': Str % Choices('feature', 'sample'),
                 'time_column': Str, 'reference_column': Str,
-                'subject_column': T_subject,
+                'subject_column': Str,
                 'filter_missing_references': Bool,
                 'drop_incomplete_subjects': Bool,
                 'drop_incomplete_timepoint': List[Str],
@@ -216,7 +216,7 @@ plugin.methods.register_function(
     inputs={'table': FeatureTable[Frequency | RelativeFrequency |
                                   PresenceAbsence]},
     parameters={'metadata': Metadata, 'time_column': Str,
-                'reference_column': Str, 'subject_column': T_subject,
+                'reference_column': Str, 'subject_column': Str,
                 'filter_missing_references': Bool,
                 'drop_incomplete_subjects': Bool,
                 'drop_incomplete_timepoint': List[Str]},
@@ -265,7 +265,7 @@ plugin.methods.register_function(
     inputs={'table': FeatureTable[Frequency | RelativeFrequency |
                                   PresenceAbsence]},
     parameters={'metadata': Metadata, 'time_column': Str,
-                'reference_column': Str, 'subject_column': T_subject,
+                'reference_column': Str, 'subject_column': Str,
                 'filter_missing_references': Bool},
     outputs=[('peds_dists', GroupDist[Ordered, Matched] % Properties("peds"))],
     parameter_descriptions={

--- a/q2_fmt/plugin_setup.py
+++ b/q2_fmt/plugin_setup.py
@@ -194,8 +194,7 @@ plugin.pipelines.register_function(
                 'filter_missing_references': Bool,
                 'drop_incomplete_subjects': Bool,
                 'drop_incomplete_timepoint': List[Str],
-                'level_delimiter': Str}
-                ,
+                'level_delimiter': Str},
     outputs=[('peds_heatmap', Visualization)],
     parameter_descriptions={},
     output_descriptions={},

--- a/q2_fmt/tests/test_engraftment.py
+++ b/q2_fmt/tests/test_engraftment.py
@@ -1101,3 +1101,30 @@ class TestPeds(TestBase):
                                                  'subject']
         self.assertEqual("Feature;1", Fs1)
         self.assertEqual("Feature;2", Fs2)
+
+    def test_rename_features_with_blank_label(self):
+        metadata_df = pd.DataFrame({
+                'id': ['sample1', 'sample2', 'sample3',
+                       'donor1'],
+                'Ref': ['donor1', 'donor1', 'donor1', float("Nan")],
+                'subject': ['sub1', 'sub1', 'sub1', float("Nan")],
+                'group': [1, 1, 1, float("Nan")]}).set_index('id')
+        metadata = Metadata(metadata_df)
+        table_df = pd.DataFrame({
+                'id': ['sample1', 'sample2', 'sample3',
+                       'donor1'],
+                'Feature;1;__': [0, 0, 1, 1],
+                'Feature;2': [0, 1, 1, 1],
+                'Feature;3': [0, 0, 1, 0]}).set_index('id')
+        feature_peds_df = feature_peds(table=table_df, metadata=metadata,
+                                       time_column="group",
+                                       reference_column="Ref",
+                                       subject_column="subject")
+        _rename_features(data=feature_peds_df, level_delimiter=";")
+        print(feature_peds_df)
+        Fs1 = feature_peds_df.set_index("id").at['Feature 1 __',
+                                                 'subject']
+        Fs2 = feature_peds_df.set_index("id").at['Feature 2',
+                                                 'subject']
+        self.assertEqual("1", Fs1)
+        self.assertEqual("2", Fs2)


### PR DESCRIPTION
This PR refactors peds-heatmap and the peds pipeline to split taxonomic labels. 

This refactor added a helper method _rename_features.
It refactored peds-heatmap so that it is not a pipeline and is a visualizer 
lastly it refactored peds pipeline to use peds-heatmap. 
