### PR TITLE
REF: remove q2-vizard from FMT distro

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -28,7 +28,6 @@ requirements:
     - qiime2 {{ qiime2_epoch }}.*
     - q2-types {{ qiime2_epoch }}.*
     - q2-stats {{ qiime2_epoch }}.*
-    - q2-vizard {{ qiime2_epoch }}.*
 
 test:
   requires:


### PR DESCRIPTION
This PR removes q2-vizard from q2-fmt's Recipe/meta.yml

