### PR TITLE
REF: rename group-timpoints to prepare-timepoints

### DIFF
--- a/q2_fmt/__init__.py
+++ b/q2_fmt/__init__.py
@@ -7,11 +7,11 @@
 # ----------------------------------------------------------------------------
 
 from ._version import get_versions
-from ._engraftment import engraftment, group_timepoints
+from ._engraftment import engraftment, prepare_timepoints
 from ._peds import sample_peds, feature_peds, peds, peds_heatmap
 
 __version__ = get_versions()['version']
 del get_versions
 
 __all__ = ['engraftment', 'sample_peds', 'feature_peds',
-           'peds', 'peds_heatmap', 'group_timepoints']
+           'peds', 'peds_heatmap', 'prepare_timepoints']

--- a/q2_fmt/_engraftment.py
+++ b/q2_fmt/_engraftment.py
@@ -20,14 +20,14 @@ def engraftment(
 ):
 
     raincloud_plot = ctx.get_action('stats', 'plot_rainclouds')
-    group_timepoints = ctx.get_action('fmt', 'group_timepoints')
+    prepare_timepoints = ctx.get_action('fmt', 'prepare_timepoints')
 
     results = []
 
-    time_dist, ref_dist = group_timepoints(diversity_measure, metadata,
-                                           time_column, reference_column,
-                                           subject_column, control_column,
-                                           filter_missing_references, where)
+    time_dist, ref_dist = prepare_timepoints(diversity_measure, metadata,
+                                             time_column, reference_column,
+                                             subject_column, control_column,
+                                             filter_missing_references, where)
 
     if compare == 'reference' or compare == 'all-pairwise':
         mann_whitney_u = ctx.get_action('stats', 'mann_whitney_u')
@@ -49,7 +49,7 @@ def engraftment(
     return tuple(results)
 
 
-def group_timepoints(
+def prepare_timepoints(
         diversity_measure: pd.Series, metadata: qiime2.Metadata,
         time_column: str, reference_column: str, subject_column: str = False,
         control_column: str = None, filter_missing_references: bool = False,

--- a/q2_fmt/_examples.py
+++ b/q2_fmt/_examples.py
@@ -68,12 +68,12 @@ def peds_dist_factory():
     )
 
 
-def group_timepoints_alpha_independent(use):
+def prepare_timepoints_alpha_independent(use):
     alpha = use.init_artifact('alpha', alpha_div_factory)
     metadata = use.init_metadata('metadata', alpha_md_factory)
 
     timepoints, references = use.action(
-        use.UsageAction('fmt', 'group_timepoints'),
+        use.UsageAction('fmt', 'prepare_timepoints'),
         use.UsageInputs(
             diversity_measure=alpha,
             metadata=metadata,
@@ -91,12 +91,12 @@ def group_timepoints_alpha_independent(use):
     references.assert_output_type('GroupDist[Unordered, Independent]')
 
 
-def group_timepoints_beta(use):
+def prepare_timepoints_beta(use):
     beta = use.init_artifact('beta', beta_div_factory)
     metadata = use.init_metadata('metadata', beta_md_factory)
 
     timepoints, references = use.action(
-        use.UsageAction('fmt', 'group_timepoints'),
+        use.UsageAction('fmt', 'prepare_timepoints'),
         use.UsageInputs(
             diversity_measure=beta,
             metadata=metadata,

--- a/q2_fmt/plugin_setup.py
+++ b/q2_fmt/plugin_setup.py
@@ -130,7 +130,7 @@ plugin.pipelines.register_function(
 )
 
 plugin.methods.register_function(
-    function=q2_fmt.group_timepoints,
+    function=q2_fmt.prepare_timepoints,
     inputs={'diversity_measure': DistanceMatrix | SampleData[AlphaDiversity]},
     parameters={'metadata': Metadata, 'time_column': Str,
                 'reference_column': Str, 'subject_column': T_subject,
@@ -178,8 +178,9 @@ plugin.methods.register_function(
     name='',
     description='',
     examples={
-        'group_timepoints_alpha_ind': ex.group_timepoints_alpha_independent,
-        'group_timepoints_beta': ex.group_timepoints_beta
+        'prepare_timepoints_alpha_ind':
+            ex.prepare_timepoints_alpha_independent,
+        'prepare_timepoints_beta': ex.prepare_timepoints_beta
     }
 )
 

--- a/q2_fmt/tests/test_engraftment.py
+++ b/q2_fmt/tests/test_engraftment.py
@@ -13,7 +13,7 @@ from skbio.stats.distance import DistanceMatrix
 from qiime2.plugin.testing import TestPluginBase
 from qiime2 import Metadata
 
-from q2_fmt._engraftment import group_timepoints
+from q2_fmt._engraftment import prepare_timepoints
 from q2_fmt._peds import (_compute_peds, sample_peds,
                           _filter_associated_reference,
                           _check_reference_column, _check_for_time_column,
@@ -43,38 +43,38 @@ class ErrorMixins:
     def test_with_time_column_input_not_in_metadata(self):
         with self.assertRaisesRegex(ValueError,
                                     'time_column.*foo.*metadata'):
-            group_timepoints(diversity_measure=self.div,
-                             metadata=self.md,
-                             time_column='foo',
-                             reference_column='relevant_donor',
-                             control_column='control')
+            prepare_timepoints(diversity_measure=self.div,
+                               metadata=self.md,
+                               time_column='foo',
+                               reference_column='relevant_donor',
+                               control_column='control')
 
     def test_with_reference_column_input_not_in_metadata(self):
         with self.assertRaisesRegex(ValueError,
                                     'reference_column.*foo.*metadata'):
-            group_timepoints(diversity_measure=self.div,
-                             metadata=self.md,
-                             time_column='days_post_transplant',
-                             reference_column='foo',
-                             control_column='control')
+            prepare_timepoints(diversity_measure=self.div,
+                               metadata=self.md,
+                               time_column='days_post_transplant',
+                               reference_column='foo',
+                               control_column='control')
 
     def test_with_control_column_input_not_in_metadata(self):
         with self.assertRaisesRegex(ValueError,
                                     'control_column.*foo.*metadata'):
-            group_timepoints(diversity_measure=self.div,
-                             metadata=self.md,
-                             time_column='days_post_transplant',
-                             reference_column='relevant_donor',
-                             control_column='foo')
+            prepare_timepoints(diversity_measure=self.div,
+                               metadata=self.md,
+                               time_column='days_post_transplant',
+                               reference_column='relevant_donor',
+                               control_column='foo')
 
     def test_with_non_numeric_time_column(self):
         with self.assertRaisesRegex(ValueError,
                                     'time_column.*categorical.*numeric'):
-            group_timepoints(diversity_measure=self.div,
-                             metadata=self.md,
-                             time_column='non_numeric_time_column',
-                             reference_column='relevant_donor',
-                             control_column='control')
+            prepare_timepoints(diversity_measure=self.div,
+                               metadata=self.md,
+                               time_column='non_numeric_time_column',
+                               reference_column='relevant_donor',
+                               control_column='control')
 
 
 class TestAlphaErrors(TestBase, ErrorMixins):
@@ -114,11 +114,12 @@ class TestGroupTimepoints(TestBase):
                   'sampleC', 'sampleD', 'sampleD']
         })
 
-        time_df, ref_df = group_timepoints(diversity_measure=self.dm,
-                                           metadata=self.md_beta,
-                                           time_column='days_post_transplant',
-                                           reference_column='relevant_donor',
-                                           control_column='control')
+        time_df, ref_df = prepare_timepoints(
+            diversity_measure=self.dm,
+            metadata=self.md_beta,
+            time_column='days_post_transplant',
+            reference_column='relevant_donor',
+            control_column='control')
 
         pd.testing.assert_frame_equal(time_df, exp_time_df)
         pd.testing.assert_frame_equal(ref_df, exp_ref_df)
@@ -144,21 +145,22 @@ class TestGroupTimepoints(TestBase):
                   'sampleC', 'sampleD', 'sampleD']
         })
 
-        time_df, ref_df = group_timepoints(diversity_measure=self.dm,
-                                           metadata=self.md_beta,
-                                           time_column='days_post_transplant',
-                                           reference_column='relevant_donor',
-                                           control_column='control',
-                                           subject_column='subject')
+        time_df, ref_df = prepare_timepoints(
+            diversity_measure=self.dm,
+            metadata=self.md_beta,
+            time_column='days_post_transplant',
+            reference_column='relevant_donor',
+            control_column='control',
+            subject_column='subject')
 
         pd.testing.assert_frame_equal(time_df, exp_time_df)
         pd.testing.assert_frame_equal(ref_df, exp_ref_df)
 
     def test_beta_dists_with_same_donor_for_all_samples(self):
-        _, ref_df = group_timepoints(diversity_measure=self.dm,
-                                     metadata=self.md_beta,
-                                     time_column='days_post_transplant',
-                                     reference_column='relevant_donor_all')
+        _, ref_df = prepare_timepoints(diversity_measure=self.dm,
+                                       metadata=self.md_beta,
+                                       time_column='days_post_transplant',
+                                       reference_column='relevant_donor_all')
 
         self.assertTrue(ref_df.empty)
 
@@ -166,11 +168,11 @@ class TestGroupTimepoints(TestBase):
         with self.assertRaisesRegex(KeyError,
                                     'Missing references for the associated'
                                     ' sample data'):
-            group_timepoints(diversity_measure=self.dm,
-                             metadata=self.md_beta,
-                             time_column='days_post_transplant',
-                             reference_column='single_donor',
-                             control_column='control')
+            prepare_timepoints(diversity_measure=self.dm,
+                               metadata=self.md_beta,
+                               time_column='days_post_transplant',
+                               reference_column='single_donor',
+                               control_column='control')
 
     def test_beta_dists_with_donors_and_one_control(self):
         exp_ref_df = pd.DataFrame({
@@ -181,11 +183,11 @@ class TestGroupTimepoints(TestBase):
             'B': ['donor2', 'donor3', 'donor3']
         })
 
-        _, ref_df = group_timepoints(diversity_measure=self.dm,
-                                     metadata=self.md_beta,
-                                     time_column='days_post_transplant',
-                                     reference_column='relevant_donor',
-                                     control_column='single_control')
+        _, ref_df = prepare_timepoints(diversity_measure=self.dm,
+                                       metadata=self.md_beta,
+                                       time_column='days_post_transplant',
+                                       reference_column='relevant_donor',
+                                       control_column='single_control')
 
         pd.testing.assert_frame_equal(ref_df, exp_ref_df)
 
@@ -204,10 +206,11 @@ class TestGroupTimepoints(TestBase):
             'B': ['donor2', 'donor3', 'donor3']
         })
 
-        time_df, ref_df = group_timepoints(diversity_measure=self.dm,
-                                           metadata=self.md_beta,
-                                           time_column='days_post_transplant',
-                                           reference_column='relevant_donor')
+        time_df, ref_df = prepare_timepoints(
+            diversity_measure=self.dm,
+            metadata=self.md_beta,
+            time_column='days_post_transplant',
+            reference_column='relevant_donor')
 
         pd.testing.assert_frame_equal(time_df, exp_time_df)
         pd.testing.assert_frame_equal(ref_df, exp_ref_df)
@@ -215,33 +218,33 @@ class TestGroupTimepoints(TestBase):
     def test_beta_dists_no_donors_with_controls(self):
         with self.assertRaisesRegex(
             TypeError,
-            r"group_timepoints\(\) missing 1 required positional argument: "
+            r"prepare_timepoints\(\) missing 1 required positional argument: "
                 "'reference_column'"):
-            group_timepoints(diversity_measure=self.dm,
-                             metadata=self.md_beta,
-                             time_column='days_post_transplant',
-                             control_column='control')
+            prepare_timepoints(diversity_measure=self.dm,
+                               metadata=self.md_beta,
+                               time_column='days_post_transplant',
+                               control_column='control')
 
     def test_beta_dists_with_invalid_ref_column(self):
         with self.assertRaisesRegex(KeyError, 'References included in the'
                                     ' metadata are missing from the diversity'
                                     ' measure.*foo.*bar.*baz'):
-            group_timepoints(diversity_measure=self.dm,
-                             metadata=self.md_beta,
-                             time_column='days_post_transplant',
-                             reference_column='invalid_ref_control',
-                             control_column='control')
+            prepare_timepoints(diversity_measure=self.dm,
+                               metadata=self.md_beta,
+                               time_column='days_post_transplant',
+                               reference_column='invalid_ref_control',
+                               control_column='control')
 
     def test_beta_dists_with_empty_diversity_series(self):
         empty_beta_series = pd.Series()
 
         with self.assertRaisesRegex(ValueError,
                                     'Empty diversity measure detected'):
-            group_timepoints(diversity_measure=empty_beta_series,
-                             metadata=self.md_beta,
-                             time_column='days_post_transplant',
-                             reference_column='relevant_donor',
-                             control_column='control')
+            prepare_timepoints(diversity_measure=empty_beta_series,
+                               metadata=self.md_beta,
+                               time_column='days_post_transplant',
+                               reference_column='relevant_donor',
+                               control_column='control')
 
     def test_beta_dists_with_extra_samples_in_metadata_not_in_diversity(self):
         extra_md = Metadata.load(self.get_data_path(
@@ -265,11 +268,12 @@ class TestGroupTimepoints(TestBase):
                   'sampleC', 'sampleD', 'sampleD']
         })
 
-        time_df, ref_df = group_timepoints(diversity_measure=self.dm,
-                                           metadata=extra_md,
-                                           time_column='days_post_transplant',
-                                           reference_column='relevant_donor',
-                                           control_column='control')
+        time_df, ref_df = prepare_timepoints(
+            diversity_measure=self.dm,
+            metadata=extra_md,
+            time_column='days_post_transplant',
+            reference_column='relevant_donor',
+            control_column='control')
 
         pd.testing.assert_frame_equal(time_df, exp_time_df)
         pd.testing.assert_frame_equal(ref_df, exp_ref_df)
@@ -281,11 +285,11 @@ class TestGroupTimepoints(TestBase):
         with self.assertRaisesRegex(ValueError,
                                     'The following IDs are not present'
                                     ' in the metadata'):
-            group_timepoints(diversity_measure=extra_dm,
-                             metadata=self.md_beta,
-                             time_column='days_post_transplant',
-                             reference_column='relevant_donor',
-                             control_column='control')
+            prepare_timepoints(diversity_measure=extra_dm,
+                               metadata=self.md_beta,
+                               time_column='days_post_transplant',
+                               reference_column='relevant_donor',
+                               control_column='control')
 
     # Alpha Diversity (Series) Test Cases
     def test_alpha_dists_with_donors_controls(self):
@@ -304,11 +308,12 @@ class TestGroupTimepoints(TestBase):
                       'control1', 'control1', 'control2', 'control2']
         })
 
-        time_df, ref_df = group_timepoints(diversity_measure=self.alpha,
-                                           metadata=self.md_alpha,
-                                           time_column='days_post_transplant',
-                                           reference_column='relevant_donor',
-                                           control_column='control')
+        time_df, ref_df = prepare_timepoints(
+            diversity_measure=self.alpha,
+            metadata=self.md_alpha,
+            time_column='days_post_transplant',
+            reference_column='relevant_donor',
+            control_column='control')
 
         pd.testing.assert_frame_equal(time_df, exp_time_df)
         pd.testing.assert_frame_equal(ref_df, exp_ref_df)
@@ -331,12 +336,13 @@ class TestGroupTimepoints(TestBase):
                       'control1', 'control1', 'control2', 'control2']
         })
 
-        time_df, ref_df = group_timepoints(diversity_measure=self.alpha,
-                                           metadata=self.md_alpha,
-                                           time_column='days_post_transplant',
-                                           reference_column='relevant_donor',
-                                           control_column='control',
-                                           subject_column='subject')
+        time_df, ref_df = prepare_timepoints(
+            diversity_measure=self.alpha,
+            metadata=self.md_alpha,
+            time_column='days_post_transplant',
+            reference_column='relevant_donor',
+            control_column='control',
+            subject_column='subject')
 
         pd.testing.assert_frame_equal(time_df, exp_time_df)
         pd.testing.assert_frame_equal(ref_df, exp_ref_df)
@@ -356,7 +362,7 @@ class TestGroupTimepoints(TestBase):
                       'control1', 'control2', 'control2']
         })
 
-        time_df, ref_df = group_timepoints(
+        time_df, ref_df = prepare_timepoints(
             diversity_measure=self.alpha, metadata=self.md_alpha,
             time_column='days_post_transplant',
             reference_column='relevant_donor_all',
@@ -369,11 +375,11 @@ class TestGroupTimepoints(TestBase):
         with self.assertRaisesRegex(KeyError,
                                     'Missing references for the associated'
                                     ' sample data'):
-            group_timepoints(diversity_measure=self.alpha,
-                             metadata=self.md_alpha,
-                             time_column='days_post_transplant',
-                             reference_column='single_donor',
-                             control_column='control')
+            prepare_timepoints(diversity_measure=self.alpha,
+                               metadata=self.md_alpha,
+                               time_column='days_post_transplant',
+                               reference_column='single_donor',
+                               control_column='control')
 
     def test_alpha_dists_with_donors_and_one_control(self):
         exp_time_df = pd.DataFrame({
@@ -390,11 +396,12 @@ class TestGroupTimepoints(TestBase):
                       'reference', 'control1']
         })
 
-        time_df, ref_df = group_timepoints(diversity_measure=self.alpha,
-                                           metadata=self.md_alpha,
-                                           time_column='days_post_transplant',
-                                           reference_column='relevant_donor',
-                                           control_column='single_control')
+        time_df, ref_df = prepare_timepoints(
+            diversity_measure=self.alpha,
+            metadata=self.md_alpha,
+            time_column='days_post_transplant',
+            reference_column='relevant_donor',
+            control_column='single_control')
 
         pd.testing.assert_frame_equal(time_df, exp_time_df)
         pd.testing.assert_frame_equal(ref_df, exp_ref_df)
@@ -413,10 +420,11 @@ class TestGroupTimepoints(TestBase):
             'group': ['reference', 'reference', 'reference', 'reference']
         })
 
-        time_df, ref_df = group_timepoints(diversity_measure=self.alpha,
-                                           metadata=self.md_alpha,
-                                           time_column='days_post_transplant',
-                                           reference_column='relevant_donor')
+        time_df, ref_df = prepare_timepoints(
+            diversity_measure=self.alpha,
+            metadata=self.md_alpha,
+            time_column='days_post_transplant',
+            reference_column='relevant_donor')
 
         pd.testing.assert_frame_equal(time_df, exp_time_df)
         pd.testing.assert_frame_equal(ref_df, exp_ref_df)
@@ -424,33 +432,33 @@ class TestGroupTimepoints(TestBase):
     def test_alpha_dists_no_donors_with_controls(self):
         with self.assertRaisesRegex(
             TypeError,
-            r"group_timepoints\(\) missing 1 required positional argument: "
+            r"prepare_timepoints\(\) missing 1 required positional argument: "
                 "'reference_column'"):
-            group_timepoints(diversity_measure=self.alpha,
-                             metadata=self.md_alpha,
-                             time_column='days_post_transplant',
-                             control_column='control')
+            prepare_timepoints(diversity_measure=self.alpha,
+                               metadata=self.md_alpha,
+                               time_column='days_post_transplant',
+                               control_column='control')
 
     def test_alpha_dists_with_invalid_ref_column(self):
         with self.assertRaisesRegex(KeyError, 'References included in the'
                                     ' metadata are missing from the diversity'
                                     ' measure.*foo.*bar.*baz'):
-            group_timepoints(diversity_measure=self.alpha,
-                             metadata=self.md_alpha,
-                             time_column='days_post_transplant',
-                             reference_column='invalid_ref_control',
-                             control_column='control')
+            prepare_timepoints(diversity_measure=self.alpha,
+                               metadata=self.md_alpha,
+                               time_column='days_post_transplant',
+                               reference_column='invalid_ref_control',
+                               control_column='control')
 
     def test_alpha_dists_with_empty_diversity_series(self):
         empty_alpha_series = pd.Series()
 
         with self.assertRaisesRegex(ValueError,
                                     'Empty diversity measure detected'):
-            group_timepoints(diversity_measure=empty_alpha_series,
-                             metadata=self.md_alpha,
-                             time_column='days_post_transplant',
-                             reference_column='relevant_donor',
-                             control_column='control')
+            prepare_timepoints(diversity_measure=empty_alpha_series,
+                               metadata=self.md_alpha,
+                               time_column='days_post_transplant',
+                               reference_column='relevant_donor',
+                               control_column='control')
 
     def test_alpha_dists_with_extra_samples_in_metadata_not_in_diversity(self):
         extra_md = Metadata.load(self.get_data_path(
@@ -471,11 +479,12 @@ class TestGroupTimepoints(TestBase):
                       'control1', 'control1', 'control2', 'control2']
         })
 
-        time_df, ref_df = group_timepoints(diversity_measure=self.alpha,
-                                           metadata=extra_md,
-                                           time_column='days_post_transplant',
-                                           reference_column='relevant_donor',
-                                           control_column='control')
+        time_df, ref_df = prepare_timepoints(
+            diversity_measure=self.alpha,
+            metadata=extra_md,
+            time_column='days_post_transplant',
+            reference_column='relevant_donor',
+            control_column='control')
 
         pd.testing.assert_frame_equal(time_df, exp_time_df)
         pd.testing.assert_frame_equal(ref_df, exp_ref_df)
@@ -486,11 +495,11 @@ class TestGroupTimepoints(TestBase):
 
         with self.assertRaisesRegex(ValueError, 'The following IDs are not'
                                     ' present in the metadata'):
-            group_timepoints(diversity_measure=extra_alpha,
-                             metadata=self.md_alpha,
-                             time_column='days_post_transplant',
-                             reference_column='relevant_donor',
-                             control_column='control')
+            prepare_timepoints(diversity_measure=extra_alpha,
+                               metadata=self.md_alpha,
+                               time_column='days_post_transplant',
+                               reference_column='relevant_donor',
+                               control_column='control')
 
     def test_examples(self):
         self.execute_examples()


### PR DESCRIPTION
This PR refactors group_timepoints to be named prepare_timepoints. 
This is in preparation for our new suite of prep methods 


prepare_timepoints to create non-nested Dist1Ds
prepare_timepoint_groups to create nested Dist1Ds
prepare_groups to create multi Dist1Ds