### PR TITLE
REF: q2-fmt tutorial fixes

### DIFF
--- a/q2_fmt/_peds.py
+++ b/q2_fmt/_peds.py
@@ -547,9 +547,10 @@ def sample_pprs(table: pd.DataFrame, metadata: qiime2.Metadata,
         metadata = _drop_incomplete_timepoints(metadata, time_column,
                                                drop_incomplete_timepoints)
         table.filter(items=metadata.index)
-    num_timepoints = _check_for_time_column(metadata, time_column)
+    num_timepoints, time_col = _check_for_time_column(metadata, time_column)
     _check_column_type(column_properties, 'time',
                        time_column, 'numeric')
+    metadata = metadata.filter(items=time_col.index, axis=0)
 
     used_references =\
         _get_to_baseline_ref(time_col=metadata[time_column],

--- a/q2_fmt/_peds.py
+++ b/q2_fmt/_peds.py
@@ -515,6 +515,9 @@ def peds_simulation(table: pd.DataFrame, metadata: qiime2.Metadata,
                     drop_incomplete_timepoints: list = None,
                     num_iterations: int = 999) -> (pd.DataFrame, pd.DataFrame):
 
+    ids_with_data = table.index
+    metadata = metadata.filter_ids(ids_to_keep=ids_with_data)
+
     metadata_df = metadata.to_dataframe()
     reference_series = _check_reference_column(metadata_df,
                                                reference_column)
@@ -523,7 +526,8 @@ def peds_simulation(table: pd.DataFrame, metadata: qiime2.Metadata,
      used_references) = _filter_associated_reference(reference_series,
                                                      metadata_df, time_column,
                                                      filter_missing_references,
-                                                     reference_column)
+                                                     reference_column,
+                                                     ids_with_data)
 
     if len(used_references.unique()) == 1:
         raise AssertionError("There is only one donated microbiome in your"

--- a/q2_fmt/_peds.py
+++ b/q2_fmt/_peds.py
@@ -135,6 +135,7 @@ def sample_peds(table: pd.DataFrame, metadata: qiime2.Metadata,
                 drop_incomplete_subjects: bool = False,
                 drop_incomplete_timepoints: list = None) -> (pd.DataFrame):
 
+    # making sure that samples exist in the table
     ids_with_data = table.index
     metadata = metadata.filter_ids(ids_to_keep=ids_with_data)
     column_properties = metadata.columns
@@ -186,6 +187,7 @@ def sample_peds(table: pd.DataFrame, metadata: qiime2.Metadata,
 def feature_peds(table: pd.DataFrame, metadata: qiime2.Metadata,
                  time_column: str, reference_column: str, subject_column: str,
                  filter_missing_references: bool = False) -> (pd.DataFrame):
+    # making sure that samples exist in the table
     ids_with_data = table.index
     metadata = metadata.filter_ids(ids_to_keep=ids_with_data)
     column_properties = metadata.columns
@@ -541,6 +543,7 @@ def sample_pprs(table: pd.DataFrame, metadata: qiime2.Metadata,
                 filter_missing_references: bool = False,
                 drop_incomplete_subjects: bool = False,
                 drop_incomplete_timepoints: list = None) -> (pd.DataFrame):
+    # making sure that samples exist in the table
     ids_with_data = table.index
     metadata = metadata.filter_ids(ids_to_keep=ids_with_data)
     column_properties = metadata.columns

--- a/q2_fmt/_peds.py
+++ b/q2_fmt/_peds.py
@@ -130,9 +130,10 @@ def sample_peds(table: pd.DataFrame, metadata: qiime2.Metadata,
                                                drop_incomplete_timepoints)
         table.filter(items=metadata.index)
     # TODO: Make incomplete samples possible move this to heatmap
-    num_timepoints = _check_for_time_column(metadata, time_column)
+    num_timepoints, time_col = _check_for_time_column(metadata, time_column)
     _check_column_type(column_properties, "time",
                        time_column, "numeric")
+    metadata = metadata.filter(items=time_col.index, axis=0)
     reference_series = _check_reference_column(metadata, reference_column)
     _check_column_type(column_properties, "reference",
                        reference_column, "categorical")
@@ -174,7 +175,7 @@ def feature_peds(table: pd.DataFrame, metadata: qiime2.Metadata,
     column_properties = metadata.columns
     metadata = metadata.to_dataframe()
 
-    _ = _check_for_time_column(metadata, time_column)
+    _, _ = _check_for_time_column(metadata, time_column)
     _check_column_type(column_properties, "time",
                        time_column, "numeric")
     reference_series = _check_reference_column(metadata, reference_column)
@@ -344,10 +345,11 @@ def _rename_features(level_delimiter, data: pd.DataFrame):
 # Filtering methods
 def _check_for_time_column(metadata, time_column):
     try:
-        num_timepoints = metadata[time_column].dropna().unique().size
+        time_col = metadata[time_column].dropna()
+        num_timepoints = time_col.unique().size
     except Exception as e:
         _check_column_missing(metadata, time_column, "time", e)
-    return num_timepoints
+    return num_timepoints, time_col
 
 
 def _check_reference_column(metadata, reference_column):

--- a/q2_fmt/tests/test_engraftment.py
+++ b/q2_fmt/tests/test_engraftment.py
@@ -877,7 +877,7 @@ class TestPeds(TestBase):
                                     ' IDs where missing references were found'
                                     ':.*'):
             _filter_associated_reference(reference_series=reference_series,
-                                         metadata=metadata_df,
+                                         metadata_df=metadata_df,
                                          time_column="group",
                                          filter_missing_references=False,
                                          reference_column="Ref",

--- a/q2_fmt/tests/test_engraftment.py
+++ b/q2_fmt/tests/test_engraftment.py
@@ -880,7 +880,8 @@ class TestPeds(TestBase):
                                          metadata=metadata_df,
                                          time_column="group",
                                          filter_missing_references=False,
-                                         reference_column="Ref")
+                                         reference_column="Ref",
+                                         ids_with_data=None)
 
     def test_incomplete_timepoints(self):
         metadata_df = pd.DataFrame({

--- a/q2_fmt/tests/test_engraftment.py
+++ b/q2_fmt/tests/test_engraftment.py
@@ -1397,6 +1397,85 @@ class TestPeds(TestBase):
         self.assertEqual("1", Fs1)
         self.assertEqual("2", Fs2)
 
+    def test_peds_nan_tp(self):
+        metadata_df = pd.DataFrame({
+            'id': ['sample1', 'sample2', 'sample3', 'sample4',
+                   'donor1', 'donor2'],
+            'Ref': ['donor1', 'donor1', 'donor1', 'donor2', np.nan,
+                    np.nan],
+            'subject': ['sub1', 'sub1', 'sub1', 'sub2', np.nan,
+                        np.nan],
+            'group': [1, 2, np.nan, 2, np.nan,
+                      np.nan]}).set_index('id')
+        metadata = Metadata(metadata_df)
+        table_df = pd.DataFrame({
+            'id': ['sample1', 'sample2', 'sample3', 'sample4',
+                   'donor1', 'donor2'],
+            'Feature1': [0, 0, 1, 1, 1, 1],
+            'Feature2': [0, 1, 1, 1, 1, 1],
+            'Feature3': [0, 0, 1, 1, 1, 1]}).set_index('id')
+        sample_peds_df = sample_peds(table=table_df, metadata=metadata,
+                                     time_column="group",
+                                     reference_column="Ref",
+                                     subject_column="subject",
+                                     drop_incomplete_subjects=True)
+        obs_samples = sample_peds_df['id'].to_list()
+        exp_sample = ['sample1', 'sample2']
+        self.assertEqual(obs_samples, exp_sample)
+
+    def test_peds_no_donor_in_table(self):
+        metadata_df = pd.DataFrame({
+            'id': ['sample1', 'sample2', 'sample3', 'sample4',
+                   'donor1', 'donor2'],
+            'Ref': ['donor1', 'donor1', 'donor2', 'donor2', np.nan,
+                    np.nan],
+            'subject': ['sub1', 'sub1', 'sub2', 'sub2', np.nan,
+                        np.nan],
+            'group': [1, 2, 1, 2, np.nan,
+                      np.nan]}).set_index('id')
+        metadata = Metadata(metadata_df)
+        table_df = pd.DataFrame({
+            'id': ['sample1', 'sample2', 'sample3', 'sample4',
+                   'donor1'],
+            'Feature1': [0, 0, 1, 1, 1],
+            'Feature2': [0, 1, 1, 1, 1],
+            'Feature3': [0, 0, 1, 1, 1]}).set_index('id')
+        with self.assertRaisesRegex(KeyError, "References included in the"
+                                    " metadata are missing from the feature"
+                                    " table.*"):
+            sample_peds(table=table_df, metadata=metadata,
+                        time_column="group",
+                        reference_column="Ref",
+                        subject_column="subject",
+                        drop_incomplete_subjects=True)
+
+    def test_peds_no_donor_in_table_flag(self):
+        metadata_df = pd.DataFrame({
+            'id': ['sample1', 'sample2', 'sample3', 'sample4',
+                   'donor1', 'donor2'],
+            'Ref': ['donor1', 'donor1', 'donor2', 'donor2', np.nan,
+                    np.nan],
+            'subject': ['sub1', 'sub1', 'sub2', 'sub2', np.nan,
+                        np.nan],
+            'group': [1, 2, 1, 2, np.nan,
+                      np.nan]}).set_index('id')
+        metadata = Metadata(metadata_df)
+        table_df = pd.DataFrame({
+            'id': ['sample1', 'sample2', 'sample3', 'sample4',
+                   'donor1'],
+            'Feature1': [0, 0, 1, 1, 1],
+            'Feature2': [0, 1, 1, 1, 1],
+            'Feature3': [0, 0, 1, 1, 1]}).set_index('id')
+        sample_peds_df = sample_peds(table=table_df, metadata=metadata,
+                                     time_column="group",
+                                     reference_column="Ref",
+                                     subject_column="subject",
+                                     drop_incomplete_subjects=True, 
+                                     filter_missing_references=True)
+        obs_samples = sample_peds_df['id'].to_list()
+        exp_sample = ['sample1', 'sample2']
+        self.assertEqual(obs_samples, exp_sample)
+
     def test_pprs(self):
         metadata_df = pd.DataFrame({
             'id': ['sample1', 'sample2', 'sample3', 'sample4',


### PR DESCRIPTION
Fixes two small issues with the q2-fmt  peds identified while creating the q2-fmt tutorial 

1. q2-fmt peds now filters out NaN timepoints
2. q2-fmt peds now filters out any donor sample that is in the metadata but not in the table with --p-filter-missing references. 

Closes #69 
