### PR TITLE
update api xref

### DIFF
--- a/book/q2_fmt_book/myst.yml
+++ b/book/q2_fmt_book/myst.yml
@@ -6,7 +6,7 @@ project:
   copyright: '2024'
   github: qiime2/q2-fmt/book
   references:
-    qiime2: https://develop.qiime2.org/en/latest/
+    q2doc-api-target: https://develop.qiime2.org/en/latest/
 
   plugins:
     - type: executable
@@ -41,4 +41,4 @@ site:
     folders: true
     pretty_urls: false
     logo: _images/logo.png
-  
+


### PR DESCRIPTION
This is paired with https://github.com/qiime2/q2doc/pull/7. [MyST External References](https://mystmd.org/guide/external-references) aren't used in this book yet, but this preps for use in the future if that becomes a thing.
