### PR TITLE
REF: imports from q2-stats to q2-types

### DIFF
--- a/q2_fmt/plugin_setup.py
+++ b/q2_fmt/plugin_setup.py
@@ -17,9 +17,9 @@ from q2_types.feature_table import (
     FeatureTable, Frequency, RelativeFrequency, PresenceAbsence)
 from q2_types.feature_data import FeatureData
 from q2_composition import DifferentialAbundance
-from q2_stats.types import (Dist1D, Matched, Independent, Ordered,
-                            Unordered, StatsTable, Pairwise,
-                            NestedOrdered)
+from q2_types.tabular import (Dist1D, Matched, Independent, Ordered,
+                              Unordered, StatsTable, Pairwise,
+                              NestedOrdered)
 import q2_fmt._examples as ex
 
 citations = Citations.load('citations.bib', package='q2_fmt')


### PR DESCRIPTION
This PR refactors q2-fmts tabular imports to import from q2-types instead of q2-stats (which has been deprecated).